### PR TITLE
reflect: remove clang build flag -fstack-protector

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,7 @@ $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 # Build BPF code
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) -g -fstack-protector -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
 	$(Q)$(LLVM_STRIP) -g $@ # strip useless DWARF info
 
 # Generate BPF skeletons


### PR DESCRIPTION
## Description

bpf code：
```c
#define TASK_COMM_LEN 16

SEC("kprobe/do_unlinkat")
int BPF_KPROBE(do_unlinkat, int dfd, struct filename *name)
{
    const char *filename;
    __u64 pid_tgid = bpf_get_current_pid_tgid();
    __u32 pid = (pid_tgid << 32) >> 32;
    __u32 tgid = pid_tgid >> 32;
    char comm[TASK_COMM_LEN];
    long ret;

    filename = BPF_CORE_READ(name, name);

    ret = bpf_get_current_comm(&comm, TASK_COMM_LEN);
    if(ret)
    {
        bpf_printk("Failed to get current task name, pid = %d\n", pid);
        return 1;
    }
    bpf_printk("KPROBE ENTRY pid = %d, filename = %s\n", pid, filename);
    return 8;
}  
```

build error：
```bash
# cd src
# make
  BPF      .output/bootstrap.bpf.o
bootstrap.bpf.c:116:16: error: A call to built-in function '__stack_chk_fail' is not supported.
int BPF_KPROBE(do_unlinkat, int dfd, struct filename *name)
               ^
1 error generated.
```
