### PR TITLE
fix: disable stack-protector for eBPF parts to fix compile error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,7 @@ $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 # Build BPF code
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
+	$(Q)$(CLANG) -g -O2 -fno-stack-protector -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
 	$(Q)$(LLVM_STRIP) -g $@ # strip useless DWARF info
 
 # Generate BPF skeletons


### PR DESCRIPTION
## Description

Fixes an error when compiling the eBPF parts of the template. The Issue I encountered seems to be caused by clang enabling stack protection for the eBPF parts of the programm, disableing it seems to fix the issue. I found this solution on <https://bugs.gentoo.org/890638>.

Fixes #7 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tried compiling before and after the change:
```console
# > git submodule update --init --recursive
# > nix develop
# > make build
make -C src
make[1]: Entering directory '/home/user/Projects/libbpf-starter-template/src'
  LIB      libbpf.a
  MKDIR    /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/bpf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/btf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/libbpf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/libbpf_errno.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/netlink.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/nlattr.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/str_error.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/libbpf_probes.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/bpf_prog_linfo.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/btf_dump.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/hashmap.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/ringbuf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/strset.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/linker.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/gen_loader.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/relo_core.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/usdt.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/zip.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/elf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/features.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/btf_iter.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/staticobjs/btf_relocate.o
  AR       /home/user/Projects/libbpf-starter-template/src/.output//libbpf/libbpf.a
  INSTALL  bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h usdt.bpf.h
  INSTALL  /home/user/Projects/libbpf-starter-template/src/.output//libbpf/libbpf.pc
  INSTALL  /home/user/Projects/libbpf-starter-template/src/.output//libbpf/libbpf.a 
  BPF      .output/bootstrap.bpf.o
clang-11: warning: argument unused during compilation: '--gcc-toolchain=/nix/store/np14qqgvvnyna3vv640hmhi21flymiia-gcc-12.2.0' [-Wunused-command-line-argument]
bootstrap.bpf.c:26:5: error: A call to built-in function '__stack_chk_fail' is not supported.
int handle_exec(struct trace_event_raw_sched_process_exec *ctx)
    ^
bootstrap.bpf.c:65:5: error: A call to built-in function '__stack_chk_fail' is not supported.
int handle_exit(struct trace_event_raw_sched_process_template* ctx)
    ^
2 errors generated.
make[1]: *** [Makefile:86: .output/bootstrap.bpf.o] Error 1
make[1]: Leaving directory '/home/user/Projects/libbpf-starter-template/src'
make: *** [Makefile:2: build] Error 2
```

**After changing compiler flags:**

```console
# > make build
make -C src
make[1]: Entering directory '/home/user/Projects/libbpf-starter-template/src'
  BPF      .output/bootstrap.bpf.o
clang-11: warning: argument unused during compilation: '--gcc-toolchain=/nix/store/np14qqgvvnyna3vv640hmhi21flymiia-gcc-12.2.0' [-Wunused-command-line-argument]
  MKDIR    bpftool
  BPFTOOL  bpftool/bootstrap/bpftool
...                        libbfd: [ OFF ]
...               clang-bpf-co-re: [ on  ]
...                          llvm: [ on  ]
...                        libcap: [ OFF ]
  MKDIR    /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/include/bpf
  INSTALL  /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/include/bpf/hashmap.h
  INSTALL  /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/include/bpf/relo_core.h
  INSTALL  /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/include/bpf/libbpf_internal.h
  MKDIR    /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/
  MKDIR    /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/
  MKDIR    /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/bpf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/btf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/libbpf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/libbpf_errno.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/netlink.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/nlattr.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/str_error.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/libbpf_probes.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/bpf_prog_linfo.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/btf_dump.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/hashmap.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/ringbuf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/strset.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/linker.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/gen_loader.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/relo_core.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/usdt.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/zip.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/elf.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/features.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/btf_iter.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/staticobjs/btf_relocate.o
  AR       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/libbpf/libbpf.a
  INSTALL  bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h usdt.bpf.h
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/main.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/common.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/json_writer.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/gen.o
  CC       /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/btf.o
  LINK     /home/user/Projects/libbpf-starter-template/src/.output/bpftool/bootstrap/bpftool
  GEN-SKEL .output/bootstrap.skel.h
  CC       .output/bootstrap.o
  BINARY   bootstrap
make[1]: Leaving directory '/home/user/Projects/libbpf-starter-template/src'
```


**Test Configuration**:

- Firmware version: ???
- Hardware: Framework Laptop 13 (Intel Core Ultra Series 1) <- I don't think this is relevant
- Toolchain: the things that get installed by the current flake.nix + flake.lock  
- OS: NixOS 25.05 x86_64 with Linux 6.16.8 Kernel
- SDK: ???

## Checklist

I don't think most of these really apply to such a small fix.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
